### PR TITLE
Removing references to Brandon Light font, adding @font-light variable

### DIFF
--- a/less/components/header.less
+++ b/less/components/header.less
@@ -18,7 +18,7 @@
         color: @light-text-color;
         text-transform: uppercase;
         font-weight: bold;
-        font: 24px brandon_grotesquelight, sans-serif;
+        font: 24px @font-light;
         text-align: center;
         position: absolute;
         top: 10px;

--- a/less/snipcart-theme.less
+++ b/less/snipcart-theme.less
@@ -53,6 +53,7 @@
 @font-bold: 'brandon_grotesquebold', Arial, sans-serif;
 @font-medium: 'brandon_grotesquemedium', Arial, sans-serif;
 @font-regular: 'brandon_grotesqueregular', Arial, sans-serif;
+@font-light: 'brandon_grotesquelight', Arial, sans-serif;
 @icon-font: 'Snipcart';
 
 // Icon fonts

--- a/less/snipcart-theme.responsive.less
+++ b/less/snipcart-theme.responsive.less
@@ -62,7 +62,7 @@
 
     #snipcart-header #snipcart-title {
         text-align: left;
-        font: 30px/105px brandon_grotesquelight, sans-serif;
+        font: 30px/105px @font-light;
         padding-left: 25px;
         width: auto;
         top: 0;


### PR DESCRIPTION
There were a couple of stray references to Brandon Light. These have now been replaced by a `@font-light` variable in `snipcart-theme.less`.
